### PR TITLE
Fix logging level not persisting between play and pause

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Editor/InteractiveSettingsWindow.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Editor/InteractiveSettingsWindow.cs
@@ -107,7 +107,7 @@ public class InteractiveSettingsWindow : EditorWindow
            };
 
         InteractivityManager.useMockData = true;
-        string loggingLevel = EditorPrefs.GetString("Interactive_LoggingLevel");
+        string loggingLevel = EditorPrefs.GetString("MixerInteractive_LoggingLevel");
         loggingLevelSelectIndex = 0;
         switch (loggingLevel)
         {
@@ -468,7 +468,7 @@ public class InteractiveSettingsWindow : EditorWindow
                     default:
                         break;
                 }
-                EditorPrefs.SetString("Mixer_LoggingLevel", newLoggingLevel);
+                EditorPrefs.SetString("MixerInteractive_LoggingLevel", newLoggingLevel);
             }
 
             SectionSeperator();


### PR DESCRIPTION
This change fixes the logging level not persisting between play and pause of the editor. We ended up losing the fix with the last merge (my fault) so this is adding it back in.