### PR TITLE
Simplify editor UI

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Editor/InteractiveSettingsWindow.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Editor/InteractiveSettingsWindow.cs
@@ -213,322 +213,68 @@ public class InteractiveSettingsWindow : EditorWindow
 
         SectionSeperator();
 
-        if (!Application.isPlaying)
+        // Share code
+        EditorGUILayout.LabelField("Share Code", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField("Share Codes allow anyone running this game to access your interactive project. It is ideal for large game studios when you don't want to manually give each person access. You can get a short code from Interactive Studio by clicking the Manage Share Settings icon.", EditorStyles.wordWrappedLabel);
+        EditorGUILayout.BeginHorizontal();
+        shareCode = EditorGUILayout.TextField("Share Code", shareCode);
+        if (GUILayout.Button("Save"))
         {
-            EditorGUILayout.LabelField("You need to be in play mode and interactive to simulate controls, participants and scenes.", EditorStyles.wordWrappedLabel);
-            if (GUILayout.Button("Play and go interactive"))
+            if (!string.IsNullOrEmpty(appID) &&
+                !string.IsNullOrEmpty(projectVersionID) &&
+                shareCode != null) // We allow an empty Share Code, because that allows the developer to clear the Share Code.
             {
-                sendMockReadyOnChangeToPlayMode = true;
-                EditorApplication.isPlaying = true;
-                mockIsInteractive = true;
+                WriteConfigFile();
+                EditorUtility.DisplayDialog("Share Code saved successfully", "Anyone running this game will now have access to the interactive project.", "Close");
             }
-            EditorGUILayout.HelpBox("Note: The button above will only work in the Unity Editor. Outside the editor, your game will need to call the InteractivityManager.StartInteractive() method.", MessageType.Info);
+            else
+            {
+                EditorUtility.DisplayDialog("Error: Could not save project information", "The OAuth Client ID, Project Version ID and Share Code cannot be empty.", "Close");
+            }
         }
-        else if (InteractivityManager.SingletonInstance.InteractivityState != InteractivityState.InteractivityEnabled &&
-            !mockIsInteractive)
+        EditorGUILayout.EndHorizontal();
+
+        SectionSeperator();
+
+        // Clear project information
+        EditorGUILayout.LabelField("Clear saved login information", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField("Clearing authentication tokens will delete any cached tokens. This is useful if you want to do testing with a new Mixer account.", EditorStyles.wordWrappedLabel);
+        if (GUILayout.Button("Clear saved login information"))
         {
-            EditorGUILayout.LabelField("You must be in interactive mode to simulate controls, participants and scenes. You can fix this by clicking the Go Interactive button below.", EditorStyles.wordWrappedLabel);
-            if (GUILayout.Button("Go interactive"))
-            {
-                mockIsInteractive = true;
-                MockReady();
-                // Add a default participant if there isn't one, otherwise simulated controls won't work.
-                if (InteractivityManager.SingletonInstance.Participants.Count == 0)
-                {
-                    MockParticipantJoin("Fake participant 1");
-                }
-            }
-            EditorGUILayout.HelpBox("Note: The button above will only work in the Unity Editor. Outside the editor, your game will need to call the InteractivityManager.StartInteractive() method.", MessageType.Info);
+            shareCode = string.Empty;
+            RemoveSavedLoginInformation();
         }
 
         SectionSeperator();
 
-        // Input Simulation
-        EditorGUILayout.LabelField("Controls", EditorStyles.boldLabel);
-        if (Application.isPlaying &&
-            (InteractivityManager.SingletonInstance.InteractivityState == InteractivityState.InteractivityEnabled ||
-            mockIsInteractive))
+        EditorGUILayout.LabelField("Log level", EditorStyles.boldLabel);
+        EditorGUILayout.LabelField("Change the amount of informational logging from the Mixer SDK. The output will appear in the Unity Console.", EditorStyles.wordWrappedLabel);
+        int oldLogLevelIndex = loggingLevelSelectIndex;
+        loggingLevelSelectIndex = EditorGUILayout.Popup("", loggingLevelSelectIndex, logLevelOptions, GUILayout.Width(96));
+        if (oldLogLevelIndex != loggingLevelSelectIndex)
         {
-            SectionSeperator();
-            EditorGUILayout.LabelField("Add new mock controls by filling out the information and clicking the Add button below.", EditorStyles.wordWrappedLabel);
-            EditorGUILayout.BeginHorizontal();
-            mockAddcontrolID = EditorGUILayout.TextField(mockAddcontrolID);
-            selectedControlIndex = EditorGUILayout.Popup("", selectedControlIndex, controlOptions, GUILayout.Width(96));
-            if (GUILayout.Button("Add", GUILayout.Width(64)))
+            string newLoggingLevel = string.Empty;
+            switch (loggingLevelSelectIndex)
             {
-                if (selectedControlIndex == CONTROL_DROPDOWN_BUTTON_INDEX)
-                {
-                    InteractivityManager.SingletonInstance.Buttons.Add(new InteractiveButtonControl(mockAddcontrolID, true, "", 0, "", ""));
-                }
-                else if (selectedControlIndex == CONTROL_JOYSTICK_BUTTON_INDEX)
-                {
-                    InteractivityManager.SingletonInstance.Joysticks.Add(new InteractiveJoystickControl(mockAddcontrolID, true, "", "", ""));
-                }
+                case 0:
+                    newLoggingLevel = "none";
+                    InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.None;
+                    break;
+                case 1:
+                    newLoggingLevel = "minimal";
+                    InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.Minimal;
+                    break;
+                case 2:
+                    newLoggingLevel = "verbose";
+                    InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.Verbose;
+                    break;
+                default:
+                    break;
             }
-            EditorGUILayout.EndHorizontal();
-
-            List<InteractiveButtonControl> buttons = InteractivityManager.SingletonInstance.Buttons as List<InteractiveButtonControl>;
-            List<InteractiveJoystickControl> joysticks = InteractivityManager.SingletonInstance.Joysticks as List<InteractiveJoystickControl>;
-            List<InteractiveControl> controls = new List<InteractiveControl>();
-            foreach (InteractiveButtonControl button in buttons)
-            {
-                controls.Add(button);
-            }
-            foreach (InteractiveJoystickControl joystick in joysticks)
-            {
-                controls.Add(joystick);
-            }
-            if (controls != null &&
-                controls.Count > 0)
-            {
-                SectionSeperator();
-                EditorGUILayout.LabelField("Controls", EditorStyles.boldLabel);
-
-                EditorGUILayout.BeginVertical();
-                for (var i = 0; i < controls.Count; i++)
-                {
-                    string currentcontrolID = controls[i].ControlID;
-                    if (currentcontrolID != null &&
-                        controls[i] as InteractiveButtonControl != null)
-                    {
-                        bool expanded;
-                        if (!expandControlDetails.TryGetValue(currentcontrolID, out expanded))
-                        {
-                            expandControlDetails.Add(currentcontrolID, expanded);
-                        }
-                        expandControlDetails[currentcontrolID] = EditorGUILayout.Foldout(expandControlDetails[currentcontrolID], currentcontrolID);
-                        if (expandControlDetails[currentcontrolID])
-                        {
-                            EditorGUILayout.BeginHorizontal();
-                            if (GUILayout.Button("Press Down"))
-                            {
-                                string buttonInputMessage = buttonMessageTemplate.Replace("{{controlID}}", currentcontrolID).Replace("{{event}}", "mousedown");
-                                InteractivityManager.SingletonInstance.SendMockWebSocketMessage(buttonInputMessage);
-                            }
-                            if (GUILayout.Button("Press Up"))
-                            {
-                                string buttonInputMessage = buttonMessageTemplate.Replace("{{controlID}}", currentcontrolID).Replace("{{event}}", "mouseup");
-                                InteractivityManager.SingletonInstance.SendMockWebSocketMessage(buttonInputMessage);
-                            }
-                            if (GUILayout.Button("Remove"))
-                            {
-                                for (int j = 0; j < InteractivityManager.SingletonInstance.Buttons.Count; j++)
-                                {
-                                    if (currentcontrolID == InteractivityManager.SingletonInstance.Buttons[j].ControlID)
-                                    {
-                                        InteractivityManager.SingletonInstance.Buttons.RemoveAt(j);
-                                    }
-                                }
-                            }
-                            EditorGUILayout.EndHorizontal();
-                        }
-                    }
-                    else if (controls[i] as InteractiveJoystickControl != null)
-                    {
-                        EditorGUILayout.BeginVertical();
-                        bool expanded;
-                        if (!expandControlDetails.TryGetValue(currentcontrolID, out expanded))
-                        {
-                            expandControlDetails.Add(currentcontrolID, expanded);
-                        }
-                        expandControlDetails[currentcontrolID] = EditorGUILayout.Foldout(expandControlDetails[currentcontrolID], currentcontrolID);
-                        if (expandControlDetails[currentcontrolID])
-                        {
-                            Vector2 mockCoordinates = new Vector2();
-                            if (!mockJoystickCoordinates.TryGetValue(currentcontrolID, out mockCoordinates))
-                            {
-                                mockJoystickCoordinates.Add(currentcontrolID, mockCoordinates);
-                            }
-                            EditorGUILayout.BeginHorizontal();
-                            EditorGUILayout.LabelField("x", GUILayout.Width(16));
-                            mockCoordinates.x = EditorGUILayout.Slider(mockJoystickCoordinates[currentcontrolID].x, -1, 1);
-                            EditorGUILayout.EndHorizontal();
-
-                            EditorGUILayout.BeginHorizontal();
-                            EditorGUILayout.LabelField("y", GUILayout.Width(16));
-                            mockCoordinates.y = EditorGUILayout.Slider(mockJoystickCoordinates[currentcontrolID].y, -1, 1);
-                            EditorGUILayout.EndHorizontal();
-                            mockJoystickCoordinates[currentcontrolID] = mockCoordinates;
-                            if (GUILayout.Button("Remove"))
-                            {
-                                for (int j = 0; j < InteractivityManager.SingletonInstance.Joysticks.Count; j++)
-                                {
-                                    if (currentcontrolID == InteractivityManager.SingletonInstance.Joysticks[j].ControlID)
-                                    {
-                                        InteractivityManager.SingletonInstance.Joysticks.RemoveAt(j);
-                                    }
-                                }
-                            }
-                            string joystickInputMessage = joystickMessageTemplate.Replace("{{controlID}}", currentcontrolID)
-                                .Replace("{{event}}", "move")
-                                .Replace("{{x}}", mockJoystickCoordinates[currentcontrolID].x.ToString())
-                                .Replace("{{y}}", mockJoystickCoordinates[currentcontrolID].y.ToString());
-
-                            InteractivityManager.SingletonInstance.SendMockWebSocketMessage(joystickInputMessage);
-                        }
-                        EditorGUILayout.EndVertical();
-                    }
-                }
-                EditorGUILayout.EndVertical();
-            }
-        }
-        else
-        {
-            EditorGUILayout.LabelField("You need to be playing and in interactive mode to simulate controls.", EditorStyles.wordWrappedLabel);
-        }
-
-        // Participant simulation
-        SectionSeperator();
-        EditorGUILayout.LabelField("Participants", EditorStyles.boldLabel);
-        if (Application.isPlaying &&
-            (InteractivityManager.SingletonInstance.InteractivityState == InteractivityState.InteractivityEnabled ||
-            mockIsInteractive))
-        {
-            EditorGUILayout.LabelField("Enter a username and click the Join button to add a participant.", EditorStyles.wordWrappedLabel);
-            EditorGUILayout.BeginHorizontal();
-            if (mockParticipantJoinUsername == null)
-            {
-                mockParticipantJoinUsername = "";
-            }
-            mockParticipantJoinUsername = EditorGUILayout.TextField(mockParticipantJoinUsername);
-            if (GUILayout.Button("Join"))
-            {
-                MockParticipantJoin(mockParticipantJoinUsername);
-            }
-            EditorGUILayout.EndHorizontal();
-            List<InteractiveParticipant> participants = InteractivityManager.SingletonInstance.Participants as List<InteractiveParticipant>;
-            if (participants != null)
-            {
-                if (participants.Count > 0)
-                {
-                    SectionSeperator();
-                    EditorGUILayout.LabelField("Participants", EditorStyles.boldLabel);
-                }
-                for (var i = 0; i < participants.Count; i++)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.LabelField(participants[i].UserName);
-                    if (GUILayout.Button("Leave"))
-                    {
-                        MockParticipantLeave(participants[i].UserName);
-                    }
-                    EditorGUILayout.EndHorizontal();
-                }
-            }
-        }
-        else
-        {
-            EditorGUILayout.LabelField("You must be playing and in interactive mode to simulate participants.", EditorStyles.wordWrappedLabel);
+            EditorPrefs.SetString("MixerInteractive_LoggingLevel", newLoggingLevel);
         }
 
         SectionSeperator();
-
-        // Scenes
-        EditorGUILayout.LabelField("Change scenes", EditorStyles.boldLabel);
-        if (Application.isPlaying &&
-            (InteractivityManager.SingletonInstance.InteractivityState == InteractivityState.InteractivityEnabled ||
-            mockIsInteractive))
-        {
-            SectionSeperator();
-
-            EditorGUILayout.LabelField("Enter an ID for the scene, then click the Change button to change to that scene.", EditorStyles.wordWrappedLabel);
-            EditorGUILayout.BeginHorizontal();
-            if (mockNewSceneSceneID == null)
-            {
-                mockNewSceneSceneID = string.Empty;
-            }
-            mockNewSceneSceneID = EditorGUILayout.TextField(mockNewSceneSceneID);
-            if (GUILayout.Button("Change"))
-            {
-                InteractivityManager.SingletonInstance.SetCurrentScene(mockNewSceneSceneID);
-            }
-            EditorGUILayout.EndHorizontal();
-        }
-        else
-        {
-            EditorGUILayout.LabelField("You need to be in play mode and interactive to change scenes.", EditorStyles.wordWrappedLabel);
-        }
-
-        SectionSeperator();
-
-        if (InteractivityManager.SingletonInstance.InteractivityState == InteractivityState.InteractivityEnabled)
-        {
-            SectionSeperator();
-            EditorGUILayout.LabelField("Stop Interactive", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Clicking the Stop Interactive button will simulate disconnecting from the Mixer Service.", EditorStyles.wordWrappedLabel);
-            if (GUILayout.Button("Stop interactive"))
-            {
-                mockIsInteractive = false;
-                InteractivityManager.SingletonInstance.StopInteractive();
-            }
-        }
-
-        showAdvancedOptions = EditorGUILayout.Foldout(showAdvancedOptions, "Advanced settings", true, EditorStyles.foldout);
-        if (showAdvancedOptions)
-        {
-            SectionSeperator();
-
-            EditorGUILayout.LabelField("Log level", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Change the amount of informational logging from the Mixer SDK. The output will appear in the Unity Console.", EditorStyles.wordWrappedLabel);
-            int oldLogLevelIndex = loggingLevelSelectIndex;
-            loggingLevelSelectIndex = EditorGUILayout.Popup("", loggingLevelSelectIndex, logLevelOptions, GUILayout.Width(96));
-            if (oldLogLevelIndex != loggingLevelSelectIndex)
-            {
-                string newLoggingLevel = string.Empty;
-                switch (loggingLevelSelectIndex)
-                {
-                    case 0:
-                        newLoggingLevel = "none";
-                        InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.None;
-                        break;
-                    case 1:
-                        newLoggingLevel = "minimal";
-                        InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.Minimal;
-                        break;
-                    case 2:
-                        newLoggingLevel = "verbose";
-                        InteractivityManager.SingletonInstance.LoggingLevel = LoggingLevel.Verbose;
-                        break;
-                    default:
-                        break;
-                }
-                EditorPrefs.SetString("MixerInteractive_LoggingLevel", newLoggingLevel);
-            }
-
-            SectionSeperator();
-
-            // Clear project information
-            EditorGUILayout.LabelField("Clear saved login information", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Clearing authentication tokens will delete any cached tokens. This is useful if you want to do testing with a new Mixer account.", EditorStyles.wordWrappedLabel);
-            if (GUILayout.Button("Clear saved login information"))
-            {
-                shareCode = string.Empty;
-                RemoveSavedLoginInformation();
-            }
-
-            SectionSeperator();
-
-            // Share code
-            EditorGUILayout.LabelField("Share Code", EditorStyles.boldLabel);
-            EditorGUILayout.LabelField("Share Codes allow anyone running this game to access your interactive project. It is ideal for large game studios when you don't want to manually give each person access. You can get a short code from Interactive Studio by clicking the Manage Share Settings icon.", EditorStyles.wordWrappedLabel);
-            EditorGUILayout.BeginHorizontal();
-            shareCode = EditorGUILayout.TextField("Share Code", shareCode);
-            if (GUILayout.Button("Save"))
-            {
-                if (!string.IsNullOrEmpty(appID) &&
-                    !string.IsNullOrEmpty(projectVersionID) &&
-                    shareCode != null) // We allow an empty Share Code, because that allows the developer to clear the Share Code.
-                {
-                    WriteConfigFile();
-                    EditorUtility.DisplayDialog("Share Code saved successfully", "Anyone running this game will now have access to the interactive project.", "Close");
-                }
-                else
-                {
-                    EditorUtility.DisplayDialog("Error: Could not save project information", "The OAuth Client ID, Project Version ID and Share Code cannot be empty.", "Close");
-                }
-            }
-            EditorGUILayout.EndHorizontal();
-        }
 
         EditorGUILayout.EndVertical();
         EditorGUILayout.EndScrollView();


### PR DESCRIPTION
As part of troubleshooting an issue over the weekend and in another case, the button in the editor that says "Go Interactive", but doesn't actually do that has caused confusion. In the early days, this feature existed to simulate going interactive, participants, inputs before the service was fully online. However, now that the service is functional the UI is causing confusion.

This change also enables us to move the more commonly used functionality out of the "advanced" section so it will be more easily discoverable. These are features like turning on logging and setting a share code which can benefit from additional visibility.