### PR TITLE
Generic way to set control properties

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveControl.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveControl.cs
@@ -78,6 +78,16 @@ namespace Microsoft.Mixer
                 0);
         }
 
+        /// <summary>
+        /// This function allows you to set any property on a control.
+        /// </summary>
+        /// <param name="name">The name of the control property.</param>
+        /// <param name="value">The value of the control property.</param>
+        public void SetProperty(string name, object value)
+        {
+            InteractivityManager.SingletonInstance.QueuePropertyUpdate(SceneID, ControlID, name, value);
+        }
+
         internal InteractiveControl(string controlID, bool disabled, string helpText, string eTag, string sceneID)
         {
             ControlID = controlID;

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
@@ -720,6 +720,16 @@ public class MixerInteractive : MonoBehaviour
     }
 
     /// <summary>
+    /// This method returns a control matching the given ID.
+    /// </summary>
+    /// <param name="controlID">The ID of the control.</param>
+    /// <returns>Returns the interactive control matching the given ID.</returns>
+    public static InteractiveControl GetControl(string controlID)
+    {
+        return InteractivityManager.SingletonInstance.GetControl(controlID);
+    }
+
+    /// <summary>
     /// Connects to the interactivity service and signals the service that the InteractivityManager is ready to recieve messages.
     /// It also, handles signals authentication events if necessary.
     /// </summary>


### PR DESCRIPTION
Provides a way to set generic control properties. This means if a button has a property called backgroundImage, that property can be set without the SDK having to explicitly "know" about it.