### PR TITLE
Fixes issue 63

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractiveHelper.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractiveHelper.cs
@@ -326,6 +326,7 @@ internal class MixerInteractiveHelper: MonoBehaviour
 
     private void WriteAuthTokensToCacheImpl()
     {
+        _queuedWriteAuthTokensToCacheRequest = false;
         PlayerPrefs.SetString("MixerInteractive-AuthToken", _authTokenValueToWriteToCache);
         PlayerPrefs.SetString("MixerInteractive-RefreshToken", _refreshTokenValueToWriteToCache);
         PlayerPrefs.Save();


### PR DESCRIPTION
The SDK was writing to disk every frame because this variable wasn't getting reset. This happened on 1st run of the SDK.