### PR TITLE
fix: MixerInteractive.ClearSavedLoginInformation() requires exit of t…

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
@@ -768,6 +768,7 @@ public class MixerInteractive : MonoBehaviour
                             if (OnGoInteractive != null)
                             {
                                 hasFiredGoInteractiveEvent = true;
+                                pendingGoInteractive = false;
                                 OnGoInteractive(this, interactivityStateChangedArgs);
                             }
                         }
@@ -1100,6 +1101,8 @@ public class MixerInteractive : MonoBehaviour
         PlayerPrefs.DeleteKey("MixerInteractive-AuthToken");
         PlayerPrefs.DeleteKey("MixerInteractive-RefreshToken");
         PlayerPrefs.Save();
+
+        InteractivityManager.SingletonInstance._authToken = string.Empty;
     }
 
     private IEnumerator InitializeCoRoutine()


### PR DESCRIPTION
…he application

Small change. Now the following will work to show the code dialog without having to exit the game:

            MixerInteractive.ClearSavedLoginInformation();
            MixerInteractive.Dispose();
            MixerInteractive.GoInteractive();