### PR TITLE
feat: Anonymous user support

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Examples/Buttons/HealthValue.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Examples/Buttons/HealthValue.cs
@@ -22,7 +22,6 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-using Microsoft;
 using Microsoft.Mixer;
 using UnityEngine;
 using UnityEngine.UI;

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Examples/Viewer controls a character/ControlCharacter.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Examples/Viewer controls a character/ControlCharacter.cs
@@ -22,18 +22,16 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-using Microsoft;
-using UnityEngine;
 using Microsoft.Mixer;
+using UnityEngine;
 
 namespace MixerInteractiveExamples
 {
     public class ControlCharacter : MonoBehaviour
     {
-
         public float speed;
 
-        private uint participantID;
+        private string participantID;
 
         // Use this for initialization
         void Start()
@@ -48,7 +46,7 @@ namespace MixerInteractiveExamples
             if (MixerInteractive.Participants.Count > 0)
             {
                 // For this example, we'll choose the 1st participant.
-                participantID = MixerInteractive.Participants[0].UserID;
+                participantID = MixerInteractive.Participants[0].SessionID;
             }
 
             // Allow the audience to control the in game character.

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveButtonControl.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveButtonControl.cs
@@ -250,7 +250,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the user who used the input control.</param>
         public bool GetButtonDown(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetButtonDown(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetButtonDownByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// Whether a given user triggered a button down since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public bool GetButtonDown(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetButtonDown(ControlID, sessionID);
         }
 
         /// <summary>
@@ -259,7 +268,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the user who used the input control.</param>
         public bool GetButtonPressed(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetButtonPressed(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetButtonPressedByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// Whether a given user triggered a button press since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public bool GetButtonPressed(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetButtonPressed(ControlID, sessionID);
         }
 
         /// <summary>
@@ -268,7 +286,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the user who used the input control.</param>
         public bool GetButtonUp(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetButtonUp(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetButtonUpByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// Whether a given user triggered a button up since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public bool GetButtonUp(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetButtonUp(ControlID, sessionID);
         }
 
         /// <summary>
@@ -277,7 +304,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the user who used the input control.</param>
         public uint GetCountOfButtonDowns(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetCountOfButtonDowns(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetCountOfButtonDownsByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// The number of button downs from a given user since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public uint GetCountOfButtonDowns(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetCountOfButtonDowns(ControlID, sessionID);
         }
 
         /// <summary>
@@ -286,7 +322,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the user who used the input control.</param>
         public uint GetCountOfButtonPresses(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetCountOfButtonPresses(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetCountOfButtonPressesByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// The number of button presses from a given user since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public uint GetCountOfButtonPresses(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetCountOfButtonPresses(ControlID, sessionID);
         }
 
         /// <summary>
@@ -296,6 +341,15 @@ namespace Microsoft.Mixer
         public uint GetCountOfButtonUps(uint userID)
         {
             return InteractivityManager.SingletonInstance._GetCountOfButtonUps(ControlID, userID);
+        }
+
+        /// <summary>
+        /// The number of button ups from a given user since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the user who used the input control.</param>
+        public uint GetCountOfButtonUps(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetCountOfButtonUps(ControlID, sessionID);
         }
 
         /// <summary>

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveJoystickControl.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveJoystickControl.cs
@@ -90,7 +90,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the participant who used the input control.</param>
         public double GetX(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetJoystickX(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetJoystickXByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// The X coordinate of the joystick for a given participant since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the participant who used the input control.</param>
+        public double GetX(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetJoystickX(ControlID, sessionID);
         }
 
         /// <summary>
@@ -99,7 +108,16 @@ namespace Microsoft.Mixer
         /// <param name="userID">The ID of the participant who used the input control.</param>
         public double GetY(uint userID)
         {
-            return InteractivityManager.SingletonInstance._GetJoystickY(ControlID, userID);
+            return InteractivityManager.SingletonInstance._GetJoystickYByUserID(ControlID, userID);
+        }
+
+        /// <summary>
+        /// The Y coordinate of the joystick for a given participant since the last call to DoWork().
+        /// </summary>
+        /// <param name="sessionID">The ID of the participant who used the input control.</param>
+        public double GetY(string sessionID)
+        {
+            return InteractivityManager.SingletonInstance._GetJoystickY(ControlID, sessionID);
         }
 
         public InteractiveJoystickControl(string controlID, InteractiveEventType type, bool enabled, string helpText, string eTag, string sceneID, Dictionary<string, object> metaproperties) : 
@@ -109,13 +127,13 @@ namespace Microsoft.Mixer
 
         internal uint _userID;
 
-        private bool TryGetJoystickStateByParticipant(uint userID, string controlID, out _InternalJoystickState joystickState)
+        private bool TryGetJoystickStateByParticipant(string sessionID, string controlID, out _InternalJoystickState joystickState)
         {
             joystickState = new _InternalJoystickState();
             bool joystickExists = false;
             bool participantExists = false;
             Dictionary<string, _InternalJoystickState> participantControls;
-            participantExists = InteractivityManager._joystickStatesByParticipant.TryGetValue(userID, out participantControls);
+            participantExists = InteractivityManager._joystickStatesByParticipant.TryGetValue(sessionID, out participantControls);
             if (participantExists)
             {
                 bool controlExists = false;

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveParticipant.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractiveParticipant.cs
@@ -45,9 +45,21 @@ namespace Microsoft.Mixer
         }
 
         /// <summary>
-        /// The the Mixer user id associated with this participant.
+        /// The the Mixer user id associated with this participant. This ID persists across sessions,
+        /// however it will be 0 for non-signed in users so we recommend using SessionID instead.
         /// </summary>
         public uint UserID
+        {
+            get;
+            internal set;
+        }
+
+        /// <summary>
+        /// The the Mixer id associated with this participant for this interactive session. 
+        /// Most of the time, you want to use this value because it will be a unique for 
+        /// identifier for anonymous users.
+        /// </summary>
+        public string SessionID
         {
             get;
             internal set;
@@ -146,7 +158,7 @@ namespace Microsoft.Mixer
             {
                 List<InteractiveButtonControl> buttonsForParticipant = new List<InteractiveButtonControl>();
                 Dictionary<string, _InternalButtonState> buttonState;
-                bool participantEntryExists = InteractivityManager._buttonStatesByParticipant.TryGetValue(UserID, out buttonState);
+                bool participantEntryExists = InteractivityManager._buttonStatesByParticipant.TryGetValue(SessionID, out buttonState);
                 if (participantEntryExists)
                 {
                     var buttonStatesByParticipantKeys = buttonState.Keys;
@@ -176,7 +188,7 @@ namespace Microsoft.Mixer
             {
                 List<InteractiveJoystickControl> joysticksForParticipant = new List<InteractiveJoystickControl>();
                 Dictionary<string, _InternalJoystickState> joystickByParticipant;
-                bool participantEntryExists = InteractivityManager._joystickStatesByParticipant.TryGetValue(UserID, out joystickByParticipant);
+                bool participantEntryExists = InteractivityManager._joystickStatesByParticipant.TryGetValue(SessionID, out joystickByParticipant);
                 if (participantEntryExists)
                 {
                     var joystickStatesByParticipantKeys = joystickByParticipant.Keys;
@@ -208,12 +220,11 @@ namespace Microsoft.Mixer
 
         internal string _etag;
         internal string _groupID;
-        internal string _sessionID;
         private List<string> channelGroups;
 
-        internal InteractiveParticipant(string newSessionID, string newEtag, uint userID, string newGroupID, string userName, List<string> newChannelGroups, uint level, DateTime lastInputAt, DateTime connectedAt, bool inputDisabled, InteractiveParticipantState state)
+        internal InteractiveParticipant(string sessionID, string newEtag, uint userID, string newGroupID, string userName, List<string> newChannelGroups, uint level, DateTime lastInputAt, DateTime connectedAt, bool inputDisabled, InteractiveParticipantState state)
         {
-            _sessionID = newSessionID;
+            SessionID = sessionID;
             UserID = userID;
             UserName = userName;
             channelGroups = newChannelGroups;

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/MixerInteractive.cs
@@ -554,7 +554,7 @@ public class MixerInteractive : MonoBehaviour
             Vector3 mousePosition = Vector3.zero;
             if (InteractivityManager._mousePositionsByParticipant.Count > 0)
             {
-                Dictionary<uint, Vector2> mousePositionsByParticipant = InteractivityManager._mousePositionsByParticipant;
+                Dictionary<string, Vector2> mousePositionsByParticipant = InteractivityManager._mousePositionsByParticipant;
                 var mousePositionByParticipantKeys = mousePositionsByParticipant.Keys;
                 float totalX = 0;
                 float totalY = 0;
@@ -966,9 +966,9 @@ public class MixerInteractive : MonoBehaviour
     public static bool GetMouseButtonDown(int buttonIndex = 0)
     {
         bool getButtonDownResult = false;
-        Dictionary<uint, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
+        Dictionary<string, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
         var mouseButtonStateByParticipantKeys = mouseButtonStateByParticipant.Keys;
-        foreach (uint mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
+        foreach (string mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
         {
             if (mouseButtonStateByParticipant[mouseButtonStateByParticipantKey].IsDown)
             {
@@ -989,9 +989,9 @@ public class MixerInteractive : MonoBehaviour
     public static bool GetMouseButton(int buttonIndex = 0)
     {
         bool getButtonDownResult = false;
-        Dictionary<uint, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
+        Dictionary<string, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
         var mouseButtonStateByParticipantKeys = mouseButtonStateByParticipant.Keys;
-        foreach (uint mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
+        foreach (string mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
         {
             if (mouseButtonStateByParticipant[mouseButtonStateByParticipantKey].IsPressed)
             {
@@ -1012,9 +1012,9 @@ public class MixerInteractive : MonoBehaviour
     public static bool GetMouseButtonUp(int buttonIndex = 0)
     {
         bool getButtonDownResult = false;
-        Dictionary<uint, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
+        Dictionary<string, _InternalMouseButtonState> mouseButtonStateByParticipant = InteractivityManager._mouseButtonStateByParticipant;
         var mouseButtonStateByParticipantKeys = mouseButtonStateByParticipant.Keys;
-        foreach (uint mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
+        foreach (string mouseButtonStateByParticipantKey in mouseButtonStateByParticipantKeys)
         {
             if (mouseButtonStateByParticipant[mouseButtonStateByParticipantKey].IsUp)
             {


### PR DESCRIPTION
The SDK now supports anonymous users. This allows non-signed in users to participate in interactive!

Note: We recommend you use InteractiveParticipant.SessionID rather than InteractiveParticipant.UserID since anonymous users will not have a unique UserID.