### PR TITLE
fix: resolve issue where a "createScenes" message would not properly be handled

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractivityManager.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractivityManager.cs
@@ -1758,7 +1758,7 @@ namespace Microsoft.Mixer
                     string keyValue = jsonReader.Value.ToString();
                     if (keyValue == WS_MESSAGE_KEY_SCENES)
                     {
-                        _scenes.Add(ReadScene(jsonReader));
+                        _scenes.AddRange(ReadScenes(jsonReader));
                     }
                 }
             }


### PR DESCRIPTION
Resolve issue where custom scenes created through a "createScenes" message via the Mixer API SendInteractiveMessage would not be properly processed.  The "OnSceneCreate" response message returns an array of scenes created, but the Unity SDK assumed it returned a single scene object.  Update the "HandleSceneCreate" message to process the response as an array.

fixes issue #104 