### PR TITLE
Websocket-sharp Editor compatibility fix

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/DLLs/Win32/websocket-sharp.dll.meta
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/DLLs/Win32/websocket-sharp.dll.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 7e7b2c95ff589084689f7a8d677a1b8d
-timeCreated: 1492389967
-licenseType: Store
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -24,6 +22,7 @@ PluginImporter:
         Exclude Win64: 0
         Exclude WindowsStoreApps: 1
         Exclude XboxOne: 1
+        Exclude iOS: 0
   - first:
       '': OSXIntel
     second:
@@ -39,7 +38,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 0
+      enabled: 1
       settings:
         Exclude Editor: 0
         Exclude Linux: 0
@@ -59,7 +58,7 @@ PluginImporter:
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
-        OS: Windows
+        OS: AnyOS
   - first:
       Facebook: Win
     second:
@@ -118,6 +117,14 @@ PluginImporter:
         PlaceholderPath: 
         SDK: AnySDK
         ScriptingBackend: AnyScriptingBackend
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/DLLs/Win32/x64/simplewebsocket.dll.meta
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/DLLs/Win32/x64/simplewebsocket.dll.meta
@@ -1,7 +1,5 @@
 fileFormatVersion: 2
 guid: 9656b1bab1b2a0645b72bd2f6a547b13
-timeCreated: 1519163993
-licenseType: Free
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -25,6 +23,7 @@ PluginImporter:
         Exclude Win64: 1
         Exclude WindowsStoreApps: 1
         Exclude XboxOne: 1
+        Exclude iOS: 1
   - first:
       '': OSXIntel
     second:
@@ -55,7 +54,7 @@ PluginImporter:
       settings:
         CPU: x86_64
         DefaultValueInitialized: true
-        OS: Windows
+        OS: AnyOS
   - first:
       Facebook: Win
     second:
@@ -114,6 +113,14 @@ PluginImporter:
         PlaceholderPath: 
         SDK: AnySDK
         ScriptingBackend: AnyScriptingBackend
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Websocket-sharp dll OS in Platform Settings changed to "Any OS" to fix compiler error on macOS.
Close #91 
Close #64