### PR TITLE
fix: _GetJoystickX not returning joystickState.X

### DIFF
--- a/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractivityManager.cs
+++ b/Source/InteractiveSDK/Assets/MixerInteractive/Source/Scripts/InteractivityManager.cs
@@ -2989,7 +2989,7 @@ namespace Microsoft.Mixer
         {
             double joystickX = 0;
             _InternalJoystickState joystickState;
-            if (string.IsNullOrEmpty(sessionID) && 
+            if (!string.IsNullOrEmpty(sessionID) && 
                 TryGetJoystickStateByParticipant(sessionID, controlID, out joystickState))
             {
                 joystickX = joystickState.X;


### PR DESCRIPTION
The conditional which checked for a non-empty ```sessionID``` in ```_GetJoystickX``` was missing a ```!``` / not operator.
This caused the 'Viewer controls a character' example to only move the character on the Y axis